### PR TITLE
Improve the README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,96 +1,95 @@
-#myadmin
--------
+# myadmin
 
-Adds admin tools Player Join Rules, curseword detection, chat commands and more to Minetest.
-
-
-#Tools
-
-2 tools included.
-
-Ultimate tool - Removes node right away with no delay and no wear. Items do not go into inventory
-				to get tool use /giveme ut
-
-Ultimate tool with drops - Same as Ultimate tool except nodes go into your inventory
-				to get tool use /giveme utd
-
-
-#Chats
-
-These are fun little chat commands. They include things like /afk, /back, /bbl, /happy, /sad, /mad
-You can get a full list of the commands by using /chats
-
-#Curse Words
-
-This is a list of words that are banned on the server. These words can be editted in the settings.txt file.
-
-
-#Privs
-
-The privs part is a set  of privs for different levels of players. You can set the level with a chat command.
-
-The levels are
-
-Super Admin
-Admin
-Moderator
-Helper
-Normal Player
-Punish
-Unpunish
-Silence
-Ghost
-
-If you want the available commands do /myadmin_commands
-Super admin is not in the list because it is reserved for above admin people but not all privs.
-
-
-#Spawn
-
-Spawn is an easy way to set spawn locations. In the settings.txt file you can set the chat command and coordinates for the spawn locations.
-
-
-#Start
-
-Start is the screen that is shown to new players when they join the server. You can list the rules in rules.txt. The player then can  agree to the rules or not.
-If the player doess not agree to the rules then he/she will be kicked from the server.
-
-
-#Extras
-
-Extras are extra neat things that  I would like to see on servers. Right now there is only one extra but I plan on adding more.
-
-/setbar is a command to set the size of the hotbar. You can set it from 1 - 16.
-
-
-
-#Names Per IP
-
-This is the names_per_ip mod from Krock. It limits the number of accounts that each ip address can have.
-This is settable in the settings.txt.
-
-
-#Guest
-
-There is a setting to decide if you want to allow names with guest in them.
-This is settable in settings.txt
-
-
-#Password
-
-A setting in the settingstxt to allow you to set whether or not you allow empty passwords.
-This can be set in minetest.conf file as well.
-
-
-#Underworld
-
-This might not fit in this mod but I added it here anyway.
-
-This is a teleporter that when set also places a teleporter below at what ever height you set it at.
-Place a teleporter and a form opens. Name the teleporter and set the depth of the other. Click set.
-When you step into the teleporter you will teleport down. After 10 seconds you can use the teleporter again.
-
-You need the myadmin_levels_super priv to place and destroy the teleporters.
+Adds admin tools, player join rules, curse word detection, chat commands and more to Minetest.
 
 
 licence - MIT
+
+-------
+
+## Tools
+
+2 tools are included.
+
+`Ultimate Tool` - Removes node right away with no delay and no wear. Items do not go into inventory.<br/>
+To get the tool use `/giveme ut`
+
+`Ultimate Tool (Drops)` - Same as `Ultimate Tool` but nodes go into your inventory.<br/>
+To get the tool use `/giveme utd`.
+
+
+## Chats
+
+These are fun little chat commands. They include things like `/afk`, `/back`, `/bbl`, `/happy`, `/sad`, `/mad`.
+
+You can get a full list of the commands by using `/chats`.
+
+## Curse Words
+
+This is a list of words that are banned on the server. These words can be edited in the `settings.txt` file.
+
+
+## Privs
+
+The privs part is a set of privs for different levels of players.
+
+The levels are
+- Super Admin
+- Admin
+- Moderator
+- Helper
+- Normal Player
+- Punish
+- Unpunish
+- Silence
+- Ghost
+
+To get the available commands use `/myadmin_commands`.<br/>
+Super Admin is not in the list because it is reserved for above Admin, not all privs.
+
+
+## Spawn
+
+Spawn is an easy way to set spawn locations. In the `settings.txt` file you can set the chat command and coordinates for the spawn locations.
+
+
+## Start
+
+Start is the screen that is shown to new players when they join the server. You can list the rules in `rules.txt`. The player then can agree to the rules or not.<br/>
+If the player does not agree to the rules then they will be kicked from the server.
+
+
+## Extras
+
+Extras are extra neat things that I would like to see on servers. Right now there is only one extra but I plan on adding more.
+
+Set the size of the hotbar with `/setbar`. You can set it to `1` - `16`.
+
+
+## Names Per IP
+
+This is the `names_per_ip` mod from Krock. It limits the number of accounts that each IP address can have.<br/>
+This is set in the `settings.txt`.
+
+
+## Guest
+
+There is a setting to decide if you want to allow names with `guest` in them.<br/>
+This is set in the `settings.txt`.
+
+
+## Password
+
+A setting in the `settings.txt` allows you to set whether or not you allow empty passwords.<br/>
+This can be set in `minetest.conf` file as well.
+
+
+## Underworld
+
+This might not fit in this mod but I added it here anyway.
+
+This is a teleporter that when set also places a teleporter below at what ever height you set it at.<br/>
+Place a teleporter and a form opens. Name the teleporter and set the depth of the other. Click `Set`.<br/>
+When you step into the teleporter you will teleport down. After 10 seconds you can use the teleporter again.<br/>
+
+You need the `myadmin_levels_super` priv to place and destroy the teleporters.


### PR DESCRIPTION
Makes the README much more readable. Still not perfect and I'm still new to Luanti, but this is a big step to the right direction.

- Make the project name stand out properly.
- Move the line specifying the license into the same header as the project name.
  - Having it in the end in an unrelated header is extremely confusing, making it look like that header's (in this case, submod's) license instead of the project's.
- Fix the submod headers.
- Use inline code tags for commands & filenames.
- Fix the intended formatting.
  - Markdown (of which GitHub uses its own extended dialect called the [GitHub Flavored Markdown](https://docs.github.com/en/get-started/writing-on-github/getting-started-with-writing-and-formatting-on-github/quickstart-for-writing-on-github)) is a quirky language, with a downright nonsensical syntax in some places.
- Make the privileges listing into a list.
  - Since I'm new, I don't know how/if the listing could be improved before I've actually tested the mod and learnt more of Luanti, but I felt like the README had to be improved regardless.